### PR TITLE
Add AES-256 encryption feature

### DIFF
--- a/ecobank256.ini
+++ b/ecobank256.ini
@@ -1,0 +1,7 @@
+coin-name=EcoBank256
+coin-symbol=EBK
+p2p-bind-port=13333
+rpc-bind-port=53333
+total-coins=1000000000
+difficulty-target=60
+genesis-block-reward=50000

--- a/src/Crypto/BankCrypto.cpp
+++ b/src/Crypto/BankCrypto.cpp
@@ -1,0 +1,23 @@
+#include <openssl/aes.h>
+#include <string.h>
+#include "BankCrypto.h"
+
+namespace Crypto {
+
+void encryptTransaction(uint8_t* data, size_t len, const uint8_t* key256) {
+    AES_KEY aesKey;
+    AES_set_encrypt_key(key256, 256, &aesKey);
+    for (size_t i = 0; i < len; i += AES_BLOCK_SIZE) {
+        AES_encrypt(data + i, data + i, &aesKey);
+    }
+}
+
+void decryptTransaction(uint8_t* data, size_t len, const uint8_t* key256) {
+    AES_KEY aesKey;
+    AES_set_decrypt_key(key256, 256, &aesKey);
+    for (size_t i = 0; i < len; i += AES_BLOCK_SIZE) {
+        AES_decrypt(data + i, data + i, &aesKey);
+    }
+}
+
+} // namespace Crypto


### PR DESCRIPTION
This pull request adds the AES-256 encryption functionality to EcoBank256. It includes:
- include/CryptoNote.h: Base definitions for CryptoNote.
- include/Crypto/BankCrypto.h: Header for AES-256 encryption.
- src/Crypto/BankCrypto.cpp: Implementation of AES-256 encryption.